### PR TITLE
Add bottom pagination in search subscribers page

### DIFF
--- a/public_html/lists/admin/inc/interfacelib.php
+++ b/public_html/lists/admin/inc/interfacelib.php
@@ -455,6 +455,9 @@ class WebblerListing
         foreach ($this->elements as $element) {
             $html .= $this->listingElement($element);
         }
+	if (!empty($this->insideNav)) {
+            $html .= sprintf('<tr><td colspan="%d">%s</td></tr>', count($this->columns) + 1, $this->insideNav);
+        }
         $html .= $this->listingEnd();
 
         if ($this->usePanel) {


### PR DESCRIPTION
<!---Thanks for contributing to phpList!-->

## Description
I noticed that in the Campaign listings there is bottom pagination already but I didn't see any when using Search subscribers.  I think it will be useful to also add bottom pagination in this page and it seems like a small change.
<!--- Please provide a general description of your changes in the Pull Request -->

## Related Issue
## Screenshots (if appropriate):